### PR TITLE
ci: update workflows to use new reusable workflows repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Default .github/workflows directory
+    schedule:
+      interval: "weekly"
+    labels:
+      - "type: chore"
+      - "work: obvious"
+      - "effort: 1"

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -4,10 +4,7 @@ on:
     types:
       - opened
       - labeled
-  pull_request:
-    types:
-      - opened
-      - labeled
+  pull_request: {}
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,7 +1,5 @@
-name: Labels
-permissions: read-all
+name: Sync Labels
 on:
-  workflow_call:
   issues: 
     types:
       - opened
@@ -10,19 +8,12 @@ on:
     types:
       - opened
       - labeled
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
-  sync-labels:
+  labels:
+    uses: outoforbitdev/reusable-workflows-library/.github/workflows/label-manager.yml@946b588a1dca9f4c9e344b1c586f333b6384312d # v1.0.0
     permissions:
-        issues: write
-    runs-on: ubuntu-latest
-    name: Sync Labels
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Set Labels
-        uses: outoforbitdev/action-label-manager@082ee285fd9918136bfa237a5cdccb78e7333538 # v0.0.2
-        id: set-labels
-        with:
-          access-token: ${{ secrets.GITHUB_TOKEN }}
+      issues: write

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -4,7 +4,10 @@ on:
     types:
       - opened
       - labeled
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - labeled
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -11,6 +11,6 @@ permissions: read-all
 
 jobs:
   labels:
-    uses: outoforbitdev/reusable-workflows-library/.github/workflows/label-manager.yml@946b588a1dca9f4c9e344b1c586f333b6384312d # v1.0.0
+    uses: outoforbitdev/reusable-workflows-library/.github/workflows/label-manager.yml@8fb3405555561af2c714e9d54dc5b9bbe3dd92f8 # v1.0.0
     permissions:
       issues: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,7 +16,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: outoforbitdev/reusable-workflows-library/.github/workflows/scorecard.yml@946b588a1dca9f4c9e344b1c586f333b6384312d # v1.0.0
+    uses: outoforbitdev/reusable-workflows-library/.github/workflows/scorecard.yml@8fb3405555561af2c714e9d54dc5b9bbe3dd92f8 # v1.0.0
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,6 +9,7 @@ on:
     - cron: "42 7 * * 4"
   push:
     branches: ["main"]
+  pull_request: {}
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,8 +1,4 @@
-# This workflow uses actions that are not certified by GitHub. They are provided
-# by a third-party and are governed by separate terms of service, privacy
-# policy, and support documentation.
-
-name: Scorecard supply-chain security
+name: Update OSSF Scorecard
 on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
@@ -13,65 +9,15 @@ on:
     - cron: "42 7 * * 4"
   push:
     branches: ["main"]
-  workflow_call:
-    secrets:
-      scorecard_token:
-        required: true
 
 # Declare default permissions as read only.
 permissions: read-all
 
 jobs:
-  analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
+  scorecard:
+    uses: outoforbitdev/reusable-workflows-library/.github/workflows/scorecard.yml@946b588a1dca9f4c9e344b1c586f333b6384312d # v1.0.0
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
-      # actions: read
-
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-
-      - name: "Run analysis"
-        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
-          # - you want to enable the Branch-Protection check on a *public* repository, or
-          # - you are installing Scorecard on a *private* repository
-          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
-          repo_token: ${{ secrets.scorecard_token || secrets.GITHUB_TOKEN }}
-
-          # Public repositories:
-          #   - Publish results to OpenSSF REST API for easy access by consumers
-          #   - Allows the repository to include the Scorecard badge.
-          #   - See https://github.com/ossf/scorecard-action#publishing-results.
-          # For private repositories:
-          #   - `publish_results` will always be set to `false`, regardless
-          #     of the value entered here.
-          publish_results: true
-
-      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
-      # format to the repository Actions tab.
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
-
-      # Upload the results to GitHub's code scanning dashboard (optional).
-      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
-      - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,6 @@ on:
     - cron: "42 7 * * 4"
   push:
     branches: ["main"]
-  pull_request: {}
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
## Summary

Update workflows to use new [reusable workflows repo](https://github.com/outoforbitdev/reusable-workflows-library)

## Testing

- [labels](https://github.com/outoforbitdev/.github/actions/runs/13877166523/job/38830911067?pr=6)
- [scorecard](https://github.com/outoforbitdev/.github/actions/runs/13877166522/job/38830911066?pr=6)