### PR TITLE
fix: use quotes for issue template yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
-name: :bug: Bug report
-about: Report something that is not working :wrench:
-labels: type: bug
+name: ':bug: Bug report'
+about: 'Report something that is not working :wrench:'
+labels: 'type: bug'
 ---
 
 ## Expected Behavior

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
-name: :rocket: Feature request
-about: Request a new feature :bulb:
-labels: type: feature
+name: ':rocket: Feature request'
+about: 'Request a new feature :bulb:'
+labels: 'type: feature'
 ---
 
 ## Context


### PR DESCRIPTION
## Summary

This PR resolves an issue where issue templates were not available by fixing the formatting of the template YAML.

### Checklist

- [x] Fill out all sections of this pull request description
- [x] Assign this pull request to yourself
- [x] Add the following labels to this pull request:
    - [x] `effort: *` to describe the amount of effort required to review this pull request
    - [x] `type: *` to describe the type of change introduced in this pull request
    - [x `work: *` to describe the complexity of the changes introduced by this pull request
- [x] Add at least one issue closed by this pull request. (If this pull request does not close an issue, consider adding an issue first.)

## Testing
NA

## Issues

Closes #14
